### PR TITLE
Upgrade to Safety CLI scan command with parameterizable stage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ __pycache__/
 # Safety CLI configuration
 .safety-project.ini
 
+# Demo repo (should be in separate directory)
+safetycli-self-healing-action-demo/
+
 # Virtual environments
 venv/
 env/

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ __pycache__/
 *.json
 .pytest_cache/
 
+# Safety CLI configuration
+.safety-project.ini
+
 # Virtual environments
 venv/
 env/

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ jobs:
 |-------|-------------|----------|----------|
 | `github_token` | GitHub token for creating issues and PRs | Yes | - |
 | `safety_api_key` | Safety CLI API key for vulnerability scanning | No* | - |
-| `stage` | Safety CLI scan stage: `dev`, `cicd`, or `production` | No | `cicd` |
+| `stage` | Safety CLI scan stage: `dev`, `cicd`, or `production` (invalid values default to `cicd`) | No | `cicd` |
 | `copilot_agent` | GitHub Copilot agent username to assign issues | No | `copilot` |
 | `project_path` | Path to Python project to scan | No | `.` |
 | `severity_threshold` | Minimum severity: `low`, `medium`, `high`, `critical` | No | `medium` |

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Self-healing security automation for Python projects using Safety CLI. This GitH
 - **Severity Filtering**: Configurable severity threshold to focus on critical issues
 - **Duplicate Prevention**: Checks for existing issues before creating new ones
 - **Rich Context**: Includes CVE details, severity levels, and recommended fixes
-- - **Intelligent Assignment**: Automatically detects Copilot availability and falls back to human assignees
+- **Intelligent Assignment**: Automatically detects Copilot availability and falls back to human assignees
+- **Flexible Stage Configuration**: Parameterizable scan stage (dev, cicd, production) for different environments
 
 ## 📋 Prerequisites
 
@@ -21,6 +22,8 @@ Self-healing security automation for Python projects using Safety CLI. This GitH
 - GitHub repository with Issues enabled
 - **Safety CLI API key** (required) - Get your free API key at [Safety CLI](https://platform.safetycli.com/cli/auth)
 - GitHub Copilot enabled on your repository (optional but recommended)
+
+> **📌 Note**: This action uses Safety CLI 3.x with the modern `scan` command. The deprecated `check` command is no longer used.
 
 ## 🔧 Usage
 
@@ -83,6 +86,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           safety_api_key: ${{ secrets.SAFETY_API_KEY }}
+          stage: 'cicd'  # Options: dev, cicd, production
           copilot_agent: 'copilot'
           project_path: './src'
           severity_threshold: 'high'
@@ -90,13 +94,13 @@ jobs:
 
 ## ⚙️ Configuration
 
-          assign_to_copilot: 'true'
 ### Inputs
 
 | Input | Description | Required | Default |
 |-------|-------------|----------|----------|
 | `github_token` | GitHub token for creating issues and PRs | Yes | - |
 | `safety_api_key` | Safety CLI API key for vulnerability scanning | No* | - |
+| `stage` | Safety CLI scan stage: `dev`, `cicd`, or `production` | No | `cicd` |
 | `copilot_agent` | GitHub Copilot agent username to assign issues | No | `copilot` |
 | `project_path` | Path to Python project to scan | No | `.` |
 | `severity_threshold` | Minimum severity: `low`, `medium`, `high`, `critical` | No | `medium` |
@@ -119,8 +123,8 @@ Without an API key, the action will skip vulnerability scanning and create no is
 
 ## 🤖 How It Works
 
-1. **Scan**: The action runs Safety CLI on your Python project
-2. **Analyze**: Parses vulnerability report and filters by severity
+1. **Scan**: The action runs Safety CLI `scan` command on your Python project using the specified stage
+2. **Analyze**: Parses vulnerability report and filters by severity threshold
 3. **Create Issues**: For each vulnerability:
    - Creates a detailed GitHub issue with CVE information
    - Includes package name, version, severity, and description
@@ -128,7 +132,7 @@ Without an API key, the action will skip vulnerability scanning and create no is
 4. **Assign to Copilot**: Automatically assigns the issue to GitHub Copilot
 5. **AI Remediation**: Copilot analyzes the issue and creates a PR with fixes
 
-6. ## 🔍 Copilot Detection & Fallback
+## 🔍 Copilot Detection & Fallback
 
 The action includes intelligent Copilot detection to ensure issues are properly assigned:
 
@@ -192,18 +196,23 @@ cd safetycli-self-healing-action
 # Install dependencies
 pip install safety requests
 
-# Run Safety scan
-safety check --json --output safety-report.json
+# Set your Safety API key
+export SAFETY_API_KEY="your-safety-api-key"
 
-# Set environment variables
+# Run Safety scan (new scan command)
+safety scan --full-report --save-json safety-report.json --disable-optional-telemetry --stage dev --non-interactive
+
+# Set environment variables for the processor
 export GITHUB_TOKEN="your-token"
 export GITHUB_REPOSITORY="owner/repo"
 export COPILOT_AGENT="copilot"
 export SEVERITY_THRESHOLD="medium"
 
-# Run the script
+# Run the script to process vulnerabilities and create issues
 python scripts/process_vulnerabilities.py
 ```
+
+**Note**: The `check` command is deprecated. Use `scan` command for Safety CLI 3.x.
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -104,10 +104,30 @@ jobs:
 | `copilot_agent` | GitHub Copilot agent username to assign issues | No | `copilot` |
 | `project_path` | Path to Python project to scan | No | `.` |
 | `severity_threshold` | Minimum severity: `low`, `medium`, `high`, `critical` | No | `medium` |
+| `max_issues` | Maximum number of issues to create (prevents spam, remaining vulnerabilities still logged) | No | `10` |
 | `assign_to_copilot` | Enable/disable Copilot assignment (true/false) | No | `true` |
 | `fallback_assignee` | Fallback GitHub username if Copilot assignment fails | No | `''` (empty) |
 
 *While technically optional, the API key is **required** for vulnerability scanning to work. Without it, the action will skip scanning.
+
+### Issue Limits
+
+The `max_issues` parameter prevents issue spam when many vulnerabilities are found:
+
+- **Default**: 10 issues per scan
+- **Recommended**: 10-20 for active projects, 5-10 for new implementations
+- **Use case**: If scanning a legacy codebase with hundreds of vulnerabilities, limit prevents flooding your issue tracker
+
+When the limit is reached:
+- Only the first N vulnerabilities create issues (by severity)
+- Remaining vulnerabilities are logged in the workflow output
+- All vulnerabilities are still recorded in the scan report
+
+**Example**: Set to 20 for larger teams:
+```yaml
+with:
+  max_issues: '20'
+```
 
 ### Safety API Key
 

--- a/action.yml
+++ b/action.yml
@@ -32,6 +32,10 @@ inputs:
     description: 'Minimum severity level to create issues for (low, medium, high, critical)'
     required: false
     default: 'medium'
+  stage:
+    description: 'Safety CLI scan stage (dev, cicd, production)'
+    required: false
+    default: 'cicd'
 
 runs:
   using: 'composite'
@@ -73,10 +77,17 @@ runs:
         
         # Run Safety scan with API key
         echo "Running Safety CLI scan..."
-        # Capture stderr separately to avoid corrupting JSON output
-        safety --stage cicd scan --output json --continue-on-error > safety-report.json 2> /tmp/safety-errors.log
+        echo "Command: safety scan --full-report --save-json safety-report.json --disable-optional-telemetry --stage ${{ inputs.stage }} --non-interactive"
+        echo ""
+
+        # Run scan - let stderr flow to runner logs for visibility
+        # JSON output goes directly to file via --save-json (not stdout)
+        safety scan --full-report --save-json safety-report.json --disable-optional-telemetry --stage ${{ inputs.stage }} --non-interactive
         SCAN_EXIT_CODE=$?
-        
+
+        echo ""
+        echo "Safety CLI exit code: $SCAN_EXIT_CODE"
+
         if [ $SCAN_EXIT_CODE -eq 0 ] || [ $SCAN_EXIT_CODE -eq 64 ]; then
           echo "✅ Safety scan completed successfully (exit code: $SCAN_EXIT_CODE)"
           if [ $SCAN_EXIT_CODE -eq 64 ]; then
@@ -94,10 +105,6 @@ runs:
           fi
         else
           echo "❌ Safety scan failed with error code: $SCAN_EXIT_CODE"
-          if [ -s /tmp/safety-errors.log ]; then
-            echo "Error output:"
-            cat /tmp/safety-errors.log
-          fi
           # Only fail on actual errors (65-69)
           if [ $SCAN_EXIT_CODE -ge 65 ] && [ $SCAN_EXIT_CODE -le 69 ]; then
             echo "This is a Safety CLI error that requires attention:"
@@ -127,7 +134,7 @@ runs:
         if [ -f safety-report.json ]; then
           echo "Report size: $(wc -c < safety-report.json) bytes"
         fi
-            
+
     - name: Process vulnerabilities and create issues
       shell: bash
       env:

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,10 @@ inputs:
     description: 'Safety CLI scan stage (dev, cicd, production)'
     required: false
     default: 'cicd'
+  max_issues:
+    description: 'Maximum number of issues to create (prevents issue spam, remaining vulnerabilities still logged)'
+    required: false
+    default: '10'
 
 runs:
   using: 'composite'
@@ -154,6 +158,7 @@ runs:
         COPILOT_AGENT: ${{ inputs.copilot_agent }}
         FALLBACK_ASSIGNEE: ${{ inputs.fallback_assignee }}
         SEVERITY_THRESHOLD: ${{ inputs.severity_threshold }}
+        MAX_ISSUES: ${{ inputs.max_issues }}
       run: |
         cd ${{ inputs.project_path }}
         python ${{ github.action_path }}/scripts/process_vulnerabilities.py

--- a/action.yml
+++ b/action.yml
@@ -90,15 +90,15 @@ runs:
 
         # Run Safety scan with API key
         echo "Running Safety CLI scan..."
-        echo "Command: safety scan --full-report --save-json safety-report.json --disable-optional-telemetry --stage $STAGE --non-interactive"
+        echo "Command: safety --stage $STAGE --disable-optional-telemetry scan --save-as json safety-report.json"
         echo ""
 
         # Disable errexit temporarily to capture exit code (GitHub Actions shells use set -e by default)
         # This allows us to capture exit code 64 (vulnerabilities found) without the shell exiting
         set +e
-        # Run scan - let stderr flow to runner logs for visibility
-        # JSON output goes directly to file via --save-json (not stdout)
-        safety scan --full-report --save-json safety-report.json --disable-optional-telemetry --stage $STAGE --non-interactive
+        # Run scan - use --save-as (documented flag) instead of --save-json
+        # Note: --stage is a global option and must come before 'scan' subcommand
+        safety --stage $STAGE --disable-optional-telemetry scan --save-as json safety-report.json
         SCAN_EXIT_CODE=$?
         set -e
 

--- a/action.yml
+++ b/action.yml
@@ -93,10 +93,14 @@ runs:
         echo "Command: safety scan --full-report --save-json safety-report.json --disable-optional-telemetry --stage $STAGE --non-interactive"
         echo ""
 
+        # Disable errexit temporarily to capture exit code (GitHub Actions shells use set -e by default)
+        # This allows us to capture exit code 64 (vulnerabilities found) without the shell exiting
+        set +e
         # Run scan - let stderr flow to runner logs for visibility
         # JSON output goes directly to file via --save-json (not stdout)
         safety scan --full-report --save-json safety-report.json --disable-optional-telemetry --stage $STAGE --non-interactive
         SCAN_EXIT_CODE=$?
+        set -e
 
         echo ""
         echo "Safety CLI exit code: $SCAN_EXIT_CODE"

--- a/action.yml
+++ b/action.yml
@@ -112,6 +112,8 @@ runs:
               echo '{"vulnerabilities":[],"skipped":false,"reason":"scan_failed"}' > safety-report.json
             fi
           fi
+          # Exit successfully for exit codes 0 or 64 (vulnerabilities found is expected)
+          exit 0
         else
           echo "❌ Safety scan failed with error code: $SCAN_EXIT_CODE"
           # Only fail on actual errors (65-69)

--- a/action.yml
+++ b/action.yml
@@ -74,15 +74,24 @@ runs:
           echo '{"vulnerabilities":[],"skipped":true,"reason":"missing_api_key"}' > safety-report.json
           exit 0
         fi
-        
+
+        # Validate stage parameter
+        STAGE="${{ inputs.stage }}"
+        if [[ ! "$STAGE" =~ ^(dev|cicd|production)$ ]]; then
+          echo "❌ Invalid stage parameter: '$STAGE'"
+          echo "Valid values are: dev, cicd, production"
+          echo "Defaulting to 'cicd' stage..."
+          STAGE="cicd"
+        fi
+
         # Run Safety scan with API key
         echo "Running Safety CLI scan..."
-        echo "Command: safety scan --full-report --save-json safety-report.json --disable-optional-telemetry --stage ${{ inputs.stage }} --non-interactive"
+        echo "Command: safety scan --full-report --save-json safety-report.json --disable-optional-telemetry --stage $STAGE --non-interactive"
         echo ""
 
         # Run scan - let stderr flow to runner logs for visibility
         # JSON output goes directly to file via --save-json (not stdout)
-        safety scan --full-report --save-json safety-report.json --disable-optional-telemetry --stage ${{ inputs.stage }} --non-interactive
+        safety scan --full-report --save-json safety-report.json --disable-optional-telemetry --stage $STAGE --non-interactive
         SCAN_EXIT_CODE=$?
 
         echo ""

--- a/action.yml
+++ b/action.yml
@@ -104,6 +104,11 @@ runs:
 
         echo ""
         echo "Safety CLI exit code: $SCAN_EXIT_CODE"
+        echo "Current directory: $(pwd)"
+        echo "Files in current directory:"
+        ls -la
+        echo "Looking for safety-report.json:"
+        find . -name "safety-report.json" -o -name "*.json" 2>/dev/null | head -10
 
         if [ $SCAN_EXIT_CODE -eq 0 ] || [ $SCAN_EXIT_CODE -eq 64 ]; then
           echo "✅ Safety scan completed successfully (exit code: $SCAN_EXIT_CODE)"

--- a/scripts/process_vulnerabilities.py
+++ b/scripts/process_vulnerabilities.py
@@ -321,14 +321,17 @@ def load_safety_report(report_path: Path) -> List[Dict]:
         if vulnerabilities:
             # Validate each vulnerability has required fields
             valid_vulns = []
-            for vuln in vulnerabilities:
+            for idx, vuln in enumerate(vulnerabilities):
                 if not isinstance(vuln, dict):
-                    print(f"⚠️  Skipping invalid vulnerability entry (not a dict)")
+                    vuln_repr = str(vuln)[:100]  # Trim to 100 chars
+                    print(f"⚠️  Skipping vulnerability at index {idx} (not a dict): {vuln_repr}")
                     continue
 
                 # Check for minimum required fields
                 if not vuln.get("package_name") or not vuln.get("vulnerability_id"):
-                    print(f"⚠️  Skipping vulnerability with missing required fields")
+                    pkg = vuln.get("package_name", "N/A")
+                    vuln_id = vuln.get("vulnerability_id", "N/A")
+                    print(f"⚠️  Skipping vulnerability at index {idx} (missing required fields): package_name={pkg}, vulnerability_id={vuln_id}")
                     continue
 
                 valid_vulns.append(vuln)


### PR DESCRIPTION
- Replace deprecated `check` command with `scan` command
- Add `stage` input parameter (dev/cicd/production) defaulting to cicd
- Update to use `--save-json` flag instead of stdout redirect
- Add `--non-interactive` flag to prevent blocking prompts in CI/CD
- Remove stderr redirect to show all output in runner logs for visibility
- Enhance JSON parser to handle new nested severity structure (cvssv3/cvssv2)
- Add bulletproof validation: validates JSON structure and required fields
- Maintain backward compatibility with old Safety CLI 2.x format
- Add .safety-project.ini to .gitignore for local Safety CLI config

This addresses the Safety CLI 3.x requirement for the new scan command format while ensuring robust parsing of vulnerability data for issue creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional stage input to choose Safety CLI scan stage (dev, cicd, production; defaults to cicd).
  * Added max_issues input to cap created issues per scan.

* **Improvements**
  * Unified severity handling across report formats and stricter vulnerability validation.
  * Improved scan command flow, exit-code handling, reporting, and logging; propagates max_issues to processing.

* **Documentation**
  * README updated with scan-based workflow, stage usage, migration notes, and max_issues behavior.

* **Chores**
  * Ignore Safety CLI configuration file and demo directory.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->